### PR TITLE
normalize_axis_index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectrofast"
-version = "0.3.2"
+version = "0.3.3"
 description = "Fast FFTW-based spectrogram computation — a drop-in replacement for scipy.signal.spectrogram"
 requires-python = ">=3.9"
 license = {text = "GPL-2.0-or-later"}

--- a/spectrofast/__init__.py
+++ b/spectrofast/__init__.py
@@ -9,7 +9,7 @@ from spectrofast._spectrogram import (
     EXHAUSTIVE,
 )
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 __all__ = [
     "spectrogram",

--- a/spectrofast/_spectrogram.py
+++ b/spectrofast/_spectrogram.py
@@ -1,6 +1,10 @@
 import os
 import sys
 import numpy as np
+try:
+    from numpy.lib.array_utils import normalize_axis_index as normalize_axis_index
+except ImportError:
+    from numpy.core.multiarray import normalize_axis_index as normalize_axis_index
 
 try:
     import numba

--- a/spectrofast/_spectrogram.py
+++ b/spectrofast/_spectrogram.py
@@ -364,7 +364,7 @@ def spectrogram(x, fs=1.0, window=('tukey', 0.25), nperseg=256,
         raise ValueError("Input array must have at least 1 dimension.")
 
     # Normalize axis
-    axis_norm = np.lib.array_utils.normalize_axis_index(axis, x.ndim)
+    axis_norm = normalize_axis_index(axis, x.ndim)
 
     # Move target axis to last position
     x = np.moveaxis(x, axis_norm, -1)


### PR DESCRIPTION
Compatible with older numpy versions:

```python
try:
    from numpy.lib.array_utils import normalize_axis_index as normalize_axis_index
except ImportError:
    from numpy.core.multiarray import normalize_axis_index as normalize_axis_index
```